### PR TITLE
Revert "cache bazelisk".

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -12,12 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: bazelbuild/setup-bazelisk@v1
-      - name: Mount bazel cache
-        uses: actions/cache@v2
-        with:
-            path: "~/.cache/bazel"
-            key: bazel
       - uses: actions/setup-node@v2
         with:
           node-version: '16'


### PR DESCRIPTION
This commit didn't actually do as much as I'd like, since we need to
'yarn install' bazelisk anyway.

This reverts commit f3a0c759a27aded14e1944b06ad93da0e90b5623.
